### PR TITLE
Support Torch 1.8 and add quantized mobilenet v3 large to evaluation

### DIFF
--- a/tutorial_eager.py
+++ b/tutorial_eager.py
@@ -49,9 +49,6 @@ def print_size_of_model(model):
 
 
 data_dir = "imagenet_1k"
-# for v2
-saved_model_dir = 'data/'
-float_model_file = 'mobilenet_pretrained_float.pth'
 
 # for v3
 saved_model_dir = "data/"

--- a/tvm_qnn_evaluation/eval_imagenet.py
+++ b/tvm_qnn_evaluation/eval_imagenet.py
@@ -132,7 +132,7 @@ def accuracy(output, target, topk=(1,)):
 
         res = []
         for k in topk:
-            correct_k = correct[:k].view(-1).float().sum(0, keepdim=True)
+            correct_k = correct[:k].contiguous().view(-1).float().sum(0, keepdim=True)
             res.append(correct_k.mul_(100.0 / batch_size))
         return res
 

--- a/tvm_qnn_evaluation/imagenet_test.py
+++ b/tvm_qnn_evaluation/imagenet_test.py
@@ -22,6 +22,7 @@ from torchvision.models.quantization import resnet as qresnet
 from torchvision.models.quantization import mobilenet as qmobilenet
 from torchvision.models.quantization import inception as qinception
 from torchvision.models.quantization import googlenet as qgooglenet
+from torchvision.models.quantization import mobilenet_v3_large as qmobilenet_v3_large
 
 import tvm
 
@@ -59,10 +60,11 @@ logging.warning(msg)
 
 # Mobilenet v2 was trained using QAT, post training calibration is disabled
 qmodels = [
-    ("resnet18", False, qresnet.resnet18(pretrained=True).eval()),
-    ("resnet50", False, qresnet.resnet50(pretrained=True).eval()),
-    ("mobilenet_v2", True, qmobilenet.mobilenet_v2(pretrained=True).eval()),
-    ("inception_v3", False, qinception.inception_v3(pretrained=True).eval()),
+    # ("resnet18", False, qresnet.resnet18(pretrained=True).eval()),
+    # ("resnet50", False, qresnet.resnet50(pretrained=True).eval()),
+    # ("mobilenet_v2", True, qmobilenet.mobilenet_v2(pretrained=True).eval()),
+    # ("inception_v3", False, qinception.inception_v3(pretrained=True).eval()),
+    ("mobilenet_v3_large", True, qmobilenet_v3_large(pretrained=True).eval())
     # ("googlenet", False, qgooglenet(pretrained=True).eval()), qgooglenet broken in torch-1.7
 ]
 

--- a/tvm_qnn_evaluation/imagenet_test.py
+++ b/tvm_qnn_evaluation/imagenet_test.py
@@ -63,7 +63,7 @@ qmodels = [
     ("resnet50", False, qresnet.resnet50(pretrained=True).eval()),
     ("mobilenet_v2", True, qmobilenet.mobilenet_v2(pretrained=True).eval()),
     ("inception_v3", False, qinception.inception_v3(pretrained=True).eval()),
-    ("googlenet", False, qgooglenet(pretrained=True).eval()),
+    # ("googlenet", False, qgooglenet(pretrained=True).eval()), qgooglenet broken in torch-1.7
 ]
 
 if torch_version_check():

--- a/tvm_qnn_evaluation/imagenet_test.py
+++ b/tvm_qnn_evaluation/imagenet_test.py
@@ -60,11 +60,11 @@ logging.warning(msg)
 
 # Mobilenet v2 was trained using QAT, post training calibration is disabled
 qmodels = [
-    # ("resnet18", False, qresnet.resnet18(pretrained=True).eval()),
-    # ("resnet50", False, qresnet.resnet50(pretrained=True).eval()),
-    # ("mobilenet_v2", True, qmobilenet.mobilenet_v2(pretrained=True).eval()),
-    # ("inception_v3", False, qinception.inception_v3(pretrained=True).eval()),
-    ("mobilenet_v3_large", True, qmobilenet_v3_large(pretrained=True).eval())
+    ("resnet18", False, qresnet.resnet18(pretrained=True).eval()),
+    ("resnet50", False, qresnet.resnet50(pretrained=True).eval()),
+    ("mobilenet_v2", True, qmobilenet.mobilenet_v2(pretrained=True).eval()),
+    ("inception_v3", False, qinception.inception_v3(pretrained=True).eval()),
+    ("mobilenet_v3_large", True, qmobilenet_v3_large(pretrained=True, quantize=True).eval())
     # ("googlenet", False, qgooglenet(pretrained=True).eval()), qgooglenet broken in torch-1.7
 ]
 
@@ -120,9 +120,11 @@ for (model_name, dummy_calib, raw_model) in qmodels:
     inp = get_imagenet_input(inception)
     pt_inp = torch.from_numpy(inp)
 
-    quantize_model(data_dir, raw_model, pt_inp, per_channel=per_channel,
-                   dummy=dummy_calib, max_samples=1000,
-                   use_random_data=use_random_data, inception=inception)
+    if "mobilenet_v3_large" not in model_name:
+        quantize_model(data_dir, raw_model, pt_inp, per_channel=per_channel,
+                       dummy=dummy_calib, max_samples=1000,
+                       use_random_data=use_random_data, inception=inception)
+
     script_module = torch.jit.trace(raw_model, pt_inp).eval()
 
     with torch.no_grad():

--- a/tvm_qnn_evaluation/imagenet_test.py
+++ b/tvm_qnn_evaluation/imagenet_test.py
@@ -62,9 +62,9 @@ logging.warning(msg)
 qmodels = [
     ("resnet18", False, qresnet.resnet18(pretrained=True).eval()),
     ("resnet50", False, qresnet.resnet50(pretrained=True).eval()),
-    ("mobilenet_v2", True, qmobilenet.mobilenet_v2(pretrained=True).eval()),
+    ("mobilenet_v2 (QAT)", True, qmobilenet.mobilenet_v2(pretrained=True).eval()),
     ("inception_v3", False, qinception.inception_v3(pretrained=True).eval()),
-    ("mobilenet_v3_large", True, qmobilenet_v3_large(pretrained=True, quantize=True).eval())
+    ("mobilenet_v3_large (QAT)", True, qmobilenet_v3_large(pretrained=True, quantize=True).eval())
     # ("googlenet", False, qgooglenet(pretrained=True).eval()), qgooglenet broken in torch-1.7
 ]
 
@@ -75,7 +75,7 @@ if torch_version_check():
     from qmobilenet_v3 import load_model
 
     model_file = "../data/mobilenetv3small-f3be529c.pth"
-    qmodels.append(("mobilenet_v3 small", False, load_model(model_file).eval()))
+    qmodels.append(("mobilenet_v3_small", False, load_model(model_file).eval()))
 else:
     print("Mobilenet v3 test requires a nightly build via pip, skipping.")
 


### PR DESCRIPTION
Updated scripts to work with the latest PyTorch 1.8. Needs https://github.com/apache/tvm/pull/7606 to run the new QAT-ed, quantized mobilenet v3 from the latest torchvision accompanying Torch 1.8 release (see their release note https://github.com/pytorch/vision/releases/tag/v0.9.0).

Here are accuracy and latency numbers on a VNNI capable Icelake laptop.

Model name | Torch-Top1 | Torch-Top5 | TVM-Top1 | TVM-Top5 | Torch latency (milli sec) | TVM latency (milli sec)
-- | -- | -- | -- | -- | -- | --
resnet18, per channel|68.90|89.70|69.00|90.10 | 6.096 |  4.869
resnet50, per channel|78.50|93.60|77.80|93.90 | 16.507 | 12.341
mobilenet_v2 (QAT), per channel|71.20|91.10|72.00|90.80 | 5.953 | 2.667
inception_v3, per channel|77.40|95.00|78.10|94.50 | 27.281 | 17.258 |
mobilenet_v3 small, per channel|60.70|81.30|60.00|80.90 | 7.547 | 1.613
mobilenet_v3_large (QAT), per channel|73.70|91.60|72.10|91.90 | 8.181 | 5.929
